### PR TITLE
Add back the ability to load routes from directory

### DIFF
--- a/examples/library/index.ts
+++ b/examples/library/index.ts
@@ -1,7 +1,7 @@
 import { newServer } from './server';
 
 (async () => {
-  const server = newServer(8000);
+  const server = await newServer(8000);
   await server.start();
   console.info(`Listening on ${server.listeningUrl()}`);
 })();

--- a/examples/library/library.acceptance.ts
+++ b/examples/library/library.acceptance.ts
@@ -1,11 +1,16 @@
 import { agent } from 'supertest';
 
 import { newServer } from './server';
+import { StubApiServer } from '../../src';
 
 describe('Library example', () => {
-  const server = newServer();
+  let server: StubApiServer;
 
-  beforeEach(() => server.start());
+    beforeEach(async () => {
+      server = await newServer();
+      await server.start();
+    });
+
   afterEach(() => server.stop());
 
   it('should work', async () => {

--- a/examples/library/routes/author.ts
+++ b/examples/library/routes/author.ts
@@ -9,7 +9,7 @@ type AuthorBody = {
   firstName: string;
   lastName: string;
 };
-const newAuthor: SimpleRouteConfig = {
+export const newAuthor: SimpleRouteConfig = {
   method: 'POST',
   path: '/authors',
   status: () => 201,
@@ -19,5 +19,3 @@ const newAuthor: SimpleRouteConfig = {
     lastname: (ctx: RequestContext<AuthorBody>) => ctx.payload?.lastName,
   },
 };
-
-export const authorRoutes = [newAuthor];

--- a/examples/library/routes/books.ts
+++ b/examples/library/routes/books.ts
@@ -20,7 +20,7 @@ const bookTemplate = {
   })),
 };
 
-const getBooks: CollectionRouteConfig = {
+export const getBooks: CollectionRouteConfig = {
   method: 'GET',
   collection: true,
   collectionSize: 3,
@@ -36,7 +36,7 @@ const getBooks: CollectionRouteConfig = {
   },
 };
 
-const getBook: SimpleRouteConfig = {
+export const getBook: SimpleRouteConfig = {
   method: 'GET',
   path: '/books/{id}',
   template: {
@@ -50,4 +50,3 @@ const getBook: SimpleRouteConfig = {
   },
 };
 
-export const booksRoutes = [getBook, getBooks];

--- a/examples/library/routes/index.ts
+++ b/examples/library/routes/index.ts
@@ -1,2 +1,0 @@
-export * from './author';
-export * from './books';

--- a/examples/library/server.ts
+++ b/examples/library/server.ts
@@ -1,7 +1,6 @@
 import { StubApiServer } from '../../src';
-import { authorRoutes, booksRoutes } from './routes';
 
 export function newServer(port?: number) {
   const server = new StubApiServer({ port });
-  return server.useRoutes([...authorRoutes, ...booksRoutes]);
+  return server.useRoutesFromDir(`${__dirname}/routes`);
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "dependencies": {
     "@hapi/hapi": "^19.1.1",
     "bluebird": "^3.7.2",
+    "globby": "^11.0.0",
     "lodash": "^4.17.15"
   }
 }

--- a/src/route-builder.ts
+++ b/src/route-builder.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
+import globby from 'globby';
 
 import { RequestContext, RouteConfig } from './route-config';
 import { processBody, processStatus } from './processors';
+import { isNil, isString } from 'lodash';
 
 export type Route = {
   method: string;
@@ -15,6 +17,16 @@ export type ResponseGenerated = {
 
 export function buildFromRouteConfig(routes: RouteConfig[]): Route[] {
   return routes.map(route => routerFromConfig(route));
+}
+
+export async function buildFromDirectory(path: string): Promise<Route[]> {
+  const files = await globby(path);
+
+  return (await Promise.all(files.map(f => import(f))))
+    // Get all values exported via `export const XXX =`
+    .flatMap(exports => Object.values(exports))
+    .filter(isValidRouteConfig)
+    .map(route => routerFromConfig(route))
 }
 
 function routerFromConfig(config: RouteConfig): Route {
@@ -33,4 +45,12 @@ async function generate(
     status: processStatus(config, context),
     body: await processBody(config, context),
   };
+}
+
+function isValidRouteConfig(input: any): input is RouteConfig {
+  if(isString(input.method) && isString(input.path) && !isNil(input.template)) {
+    return true;
+  }
+
+  return  false;
 }

--- a/src/stub-api-server.ts
+++ b/src/stub-api-server.ts
@@ -2,7 +2,7 @@ import { Server } from '@hapi/hapi';
 import { notImplemented } from '@hapi/boom';
 
 import { RouteConfig } from './route-config';
-import { buildFromRouteConfig, Route } from './route-builder';
+import { buildFromDirectory, buildFromRouteConfig, Route } from './route-builder';
 
 export type StubApiServerOptions = {
   port?: number;
@@ -26,6 +26,12 @@ export class StubApiServer {
 
   public useRoutes(routes: RouteConfig[]) {
     buildFromRouteConfig(routes).map(r => this.addRoute(r));
+    return this;
+  }
+
+  public async useRoutesFromDir(path: string) {
+    (await buildFromDirectory(path))
+      .map(r => this.addRoute(r));
     return this;
   }
 

--- a/test/acceptance/initialization.acceptance.ts
+++ b/test/acceptance/initialization.acceptance.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { agent } from 'supertest';
 
 import { RouteConfig, StubApiServer } from '../../src';
@@ -42,5 +44,25 @@ describe('stub-api-server should', () => {
 
     const response = await agent(stub.listeningUrl()).get('/hello');
     expect(response.status).toBe(200);
+  });
+
+  it('load routes from directory', async () => {
+    stub = await new StubApiServer().useRoutesFromDir(
+      path.resolve('./test/stub-config'),
+    );
+    await stub.start();
+    const stubServer = agent(stub.listeningUrl());
+
+    let response = await stubServer.get('/route1');
+    expect(response.status).toBe(200);
+
+    response = await stubServer.get('/a/route2/a');
+    expect(response.status).toBe(200);
+
+    response = await stubServer.get('/a/route2/b');
+    expect(response.status).toBe(200);
+
+    response = await stubServer.get('/boom');
+    expect(response.status).toBe(501);
   });
 });

--- a/test/stub-config/invalid-routes.ts
+++ b/test/stub-config/invalid-routes.ts
@@ -1,0 +1,22 @@
+export const noPath = {
+  method: 'GET',
+  template: { message: 'route1' },
+};
+
+export const noMethod = {
+  path: '/boom',
+  template: { message: 'route1' },
+};
+
+export const noTemplate = {
+  method: 'GET',
+  path: '/boom',
+};
+
+export const nothingRelatedToARouteConfig = [{
+  name: 'John',
+}];
+
+export default {
+  name: 'Jane',
+}

--- a/test/stub-config/route1.ts
+++ b/test/stub-config/route1.ts
@@ -1,9 +1,7 @@
 import { RouteConfig } from '../../src';
 
-const configRoute1: RouteConfig = {
+export const configRoute1: RouteConfig = {
   method: 'GET',
   path: '/route1',
   template: { message: 'route1' },
 };
-
-export default configRoute1;

--- a/test/stub-config/sub/route2.ts
+++ b/test/stub-config/sub/route2.ts
@@ -1,14 +1,13 @@
 import { RouteConfig } from '../../../src';
 
-const configRoute2a: RouteConfig = {
+export const configRoute2a: RouteConfig = {
   method: 'GET',
   path: '/a/route2/a',
   template: { message: 'route2a' },
 };
-const configRoute2b: RouteConfig = {
+
+export const configRoute2b: RouteConfig = {
   method: 'GET',
   path: '/a/route2/b',
   template: { message: 'route2b' },
 };
-
-export default [configRoute2a, configRoute2b];


### PR DESCRIPTION
The goal of this PR is to enable loading of all "named const exported" routes within a directory. It will load all routes exported with: 
```ts
// In test/stub-config/Route1.ts
export const getRoute1 = {
  method: 'GET',
  path: '/route1',
  template: { message: 'route1' },	  
}

// In tests 
await new StubApiServer().useRoutesFromDir('./stub-config');

```

It could be useful for projects with a lot of routes to stub, to avoid importing dozen of files.

To discuss and improve:
 - For now, there is only a simple check to be sure we are loading only things matching `RouteConfig` type
 - `useRoutesFromDir` is returning a promise but `useRoutes` doesn't, I think it would be better to have the same signature